### PR TITLE
env: Support vscode devcontainer and pre-commit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,77 @@
+{
+    "name": "DevContainer for MMIntegrated",
+    # Make sure to build docker container in advance
+    "image": "mmintegrated:latest",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "eamodio.gitlens",
+                "njpwerner.autodocstring",
+                "aaron-bond.better-comments",
+                "streetsidesoftware.code-spell-checker",
+                "mhutchie.git-graph",
+                "donjayamanne.githistory",
+                "oderwat.indent-rainbow",
+                "bierner.markdown-preview-github-styles",
+                "PKief.material-icon-theme",
+                "christian-kohler.path-intellisense",
+                "ms-python.vscode-pylance",
+                "ms-python.python",
+                "KevinRose.vsc-python-indent",
+                "davidhouchin.whitespace-plus",
+                "ms-python.flake8",
+                "ms-python.isort",
+                "eeyore.yapf"
+            ],
+            "settings": {
+                "editor.renderWhitespace": "all",
+                "editor.renderControlCharacters": true,
+                "editor.minimap.enabled": false,
+                "editor.rulers": [
+                    120
+                ],
+                "editor.defaultFormatter": "eeyore.yapf",
+                "editor.formatOnPaste": true,
+                "editor.formatOnSave": true,
+                "editor.formatOnType": true,
+                "files.autoGuessEncoding": true,
+                "diffEditor.ignoreTrimWhitespace": false,
+                "diffEditor.codeLens": true,
+                "workbenchi.colorTheme": "Github Dark",
+                "python.languageServer": "Pylance",
+                "flake8.args": [
+                    "--max-line-length=120"
+                ],
+                "yapf.args": [
+                    "--style='{based_on_style:pep8, column_limit: 120, indent_width: 4}'"
+                ],
+                "isort.args": [
+                    "--profile=yapf"
+                ]
+            }
+        }
+    },
+    "workspaceFolder": "/home/${localEnv:LOGNAME}/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind",
+    "postCreateCommand": "bash ./.devcontainer/postCreate.sh",
+    "runArgs": [
+        "--rm",
+        "-it",
+        "--gpus",
+        "all",
+        "--net=host",
+        "--ulimit",
+        "memlock=-1",
+        "--ulimit",
+        "stack=67108864",
+        "--name",
+        "pythorch-infinity-dev"
+    ],
+    "forwardPorts": [
+        8888
+    ],
+    "mounts": [
+        // Add mount configuration here
+        // example: "source=xxx,target=${containerWorkspaceFolder}/xxx,type=bind"
+    ]
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,7 @@
+git config --global --add safe.directory /home/$(whoami)/workspace
+git config --global core.editor vim
+
+pre-commit install
+# Enable tab-completion for git
+echo "source /usr/share/bash-completion/completions/git" >> ~/.bashrc
+source /usr/share/bash-completion/completions/git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+default_language_version:
+  python: python3.10
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-symlinks
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: [--maxkb=100]
+        stages:
+          - commit
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: requirements-txt-fixer
+      - id: double-quote-string-fixer
+      - id: check-merge-conflict
+      - id: fix-encoding-pragma
+        args: [--remove]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        args:
+          - --max-line-length=120
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: [--profile=yapf]
+  - repo: https://github.com/google/yapf
+    rev: v0.40.2
+    hooks:
+      - id: yapf
+        args:
+          - --style="{based_on_style:pep8, column_limit:120, indent_width:4}"
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17
+    hooks:
+      - id: mdformat
+        args: ["--number"]
+        additional_dependencies:
+          - mdformat-openmmlab
+          - mdformat_frontmatter
+          - linkify-it-py
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        name: pydocstyle
+        entry: pydocstyle
+        args:
+          - --convention=google
+          - --count
+          # D100: Missing docstring in public module
+          # D104: Missing docstring in public package
+          - --add-ignore=D100,D104

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Introduction
+
 MMIntegrated is an open source integrated training toolbox based on [OpenMMMLab](https://openmmlab.com/) project.
 
 The main branch works with PyTorch 2.0.
 
 # Installation
+
 Please refer to [Installation](./docs/installation.md) for installation instructions.
 
 # Acknowledgement
+
 - [mmengine](https://github.com/open-mmlab/mmengine)
 - [mmcv](https://github.com/open-mmlab/mmcv)
 - [mmdetection](https://github.com/open-mmlab/mmdetection)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The main branch works with PyTorch 2.0.
 
 Please refer to [Installation](./docs/installation.md) for installation instructions.
 
+# Code development
+
+Please use [vscode devcontainer](https://code.visualstudio.com/docs/devcontainers/containers).
+
 # Acknowledgement
 
 - [mmengine](https://github.com/open-mmlab/mmengine)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN pip --no-cache-dir install \
 # Force albumentations not to update opencv
 RUN pip install -U albumentations --no-binary qudida,albumentations
 
-RUN mim install mmengine==0.9.0 "mmcv==2.0.1" "mmdet==3.1.0" "mmsegmentation==1.2.0" "mmdet3d==1.2.0" "mmpose==1.2.0" "mmpretrain==1.1.0"
+RUN mim install mmengine==0.9.0 "mmcv==2.0.1" "mmdet==3.2.0" "mmsegmentation==1.2.0" "mmdet3d==1.3.0" "mmpose==1.2.0" "mmpretrain==1.1.0"
 
 # ----------------------------------------------------#
 # Create non root user

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,6 +87,7 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
     # Add sudo support.
+    && usermod -aG sudo $USERNAME \
     && apt update \
     && apt install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build -t mmIntegrated:latest -f docker/Dockerfile . --build-arg USERNAME=$LOGNAME --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)
+docker build -t mmintegrated:latest -f docker/Dockerfile . --build-arg USERNAME=$LOGNAME --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ docker/build_docker.sh
 # Run docker container
 
 ```bash
-docker run --rm -it --name CONTAINER_NAME -v HOST_PATH:CONTAINER_PATH --net=host --ulimit memlock=-1 --ulimit stack=67108864 mmIntegrated:latest
+docker run --rm -it --name CONTAINER_NAME -v HOST_PATH:CONTAINER_PATH --net=host --ulimit memlock=-1 --ulimit stack=67108864 mmintegrated:latest
 ```
 
 # Code development


### PR DESCRIPTION
## Motivation

I want to add a linter or something to keep the code clean.

## Change Details

Add pre-commit config
- python support
  - isort
  - yapf
  - flake8
- documentation support
  - mdformat
  - codespell 
  - pydocstile

Add devcontainer config
- Extensions
```
           "extensions": [
                "eamodio.gitlens",
                "njpwerner.autodocstring",
                "aaron-bond.better-comments",
                "streetsidesoftware.code-spell-checker",
                "mhutchie.git-graph",
                "donjayamanne.githistory",
                "oderwat.indent-rainbow",
                "bierner.markdown-preview-github-styles",
                "PKief.material-icon-theme",
                "christian-kohler.path-intellisense",
                "ms-python.vscode-pylance",
                "ms-python.python",
                "KevinRose.vsc-python-indent",
                "davidhouchin.whitespace-plus",
                "ms-python.flake8",
                "ms-python.isort",
                "eeyore.yapf"
            ],
```

Update mmdetection and mmdetection3d version

## How to use

<!--- Describe an example of the use of this feature. --->

## How you tested

<!--- Describe how the functionality was tested. Show how you ran unit tests on this functionality. --->

## Limitation (Optional)

<!--- Please describe any restrictions on this newly added feature --->

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.
