### PR TITLE
env: Update/Fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,6 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        args: [--profile=yapf]
   - repo: https://github.com/google/yapf
     rev: v0.40.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: requirements-txt-fixer
-      - id: double-quote-string-fixer
       - id: check-merge-conflict
       - id: fix-encoding-pragma
         args: [--remove]
@@ -28,16 +27,24 @@ repos:
       - id: flake8
         args:
           - --max-line-length=120
+          # E203 : Whitespace before ':'
+          - --extend-ignore=E203
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:
       - id: isort
-  - repo: https://github.com/google/yapf
-    rev: v0.40.2
-    hooks:
-      - id: yapf
         args:
-          - --style={based_on_style:pep8, column_limit:120, indent_width:4}
+          - --profile=black
+        stages:
+          - commit
+  - repo: https://github.com/psf/black
+    rev: 23.10.0
+    hooks:
+      - id: black
+        args:
+          - --line-length=120
+        stages:
+          - commit
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.17
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     hooks:
       - id: yapf
         args:
-          - --style="{based_on_style:pep8, column_limit:120, indent_width:4}"
+          - --style={based_on_style:pep8, column_limit:120, indent_width:4}
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.17
     hooks:


### PR DESCRIPTION
## Motivation

- Since yapf formatter didn't work well in pre-commit (I didn't investigate the root cause), I have to change formatter.

## Change Details

- Change formatter in pre-commit-config.yaml from yapf to black
  - Also modified other tools's setting based on [this documentation](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html). 

## How to use

<!--- Describe an example of the use of this feature. --->

## How you tested

<!--- Describe how the functionality was tested. Show how you ran unit tests on this functionality. --->

## Limitation (Optional)

<!--- Please describe any restrictions on this newly added feature --->

## Checklist

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.
