### PR TITLE
fix: Resolve error of mmseg

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
                 "davidhouchin.whitespace-plus",
                 "ms-python.flake8",
                 "ms-python.isort",
-                "eeyore.yapf"
+                "ms-python.black-formatter"
             ],
             "settings": {
                 "editor.renderWhitespace": "all",
@@ -30,7 +30,7 @@
                 "editor.rulers": [
                     120
                 ],
-                "editor.defaultFormatter": "eeyore.yapf",
+                "editor.defaultFormatter": "ms-python.black-formatter",
                 "editor.formatOnPaste": true,
                 "editor.formatOnSave": true,
                 "editor.formatOnType": true,
@@ -40,13 +40,14 @@
                 "workbenchi.colorTheme": "Github Dark",
                 "python.languageServer": "Pylance",
                 "flake8.args": [
-                    "--max-line-length=120"
+                    "--max-line-length=120",
+                    "--extend-ignore=E203"
                 ],
-                "yapf.args": [
-                    "--style='{based_on_style:pep8, column_limit: 120, indent_width: 4}'"
+                "black-formatter.args": [
+                    "--line-length=120"
                 ],
                 "isort.args": [
-                    "--profile=yapf"
+                    "--profile=black"
                 ]
             }
         }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,12 +69,13 @@ RUN pip --no-cache-dir install \
     opencv-python-headless==4.7.0.72 \
     pre-commit \
     openmim \
+    ftfy \
     && python -m ipykernel.kernelspec
 
 # Force albumentations not to update opencv
 RUN pip install -U albumentations --no-binary qudida,albumentations
 
-RUN mim install mmengine==0.9.0 "mmcv==2.0.1" "mmdet==3.2.0" "mmsegmentation==1.2.0" "mmdet3d==1.3.0" "mmpose==1.2.0" "mmpretrain==1.1.0"
+RUN mim install mmengine==0.9.0 "mmcv==2.0.1" "mmdet==3.2.0" "mmsegmentation==1.2.1" "mmdet3d==1.3.0" "mmpose==1.2.0" "mmpretrain==1.1.0"
 
 # ----------------------------------------------------#
 # Create non root user

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,4 +16,6 @@ docker run --rm -it --name CONTAINER_NAME -v HOST_PATH:CONTAINER_PATH --net=host
 
 Code development of this repository is expected to be done by using vscode devcontainer.
 
-TODO: Add description
+1. Build docker container
+2. Open command palette (ctl + shift + P)
+3. Select "Dev Containers: Reopen in Container" or "Dev Containers: Rebuild and Reopen in Container"


### PR DESCRIPTION
## Motivation

Resolve `No such file mmseg/utils/bpe_simple_vocab_16e6.txt.gz` error due to mmsegmentation.

### Background

When I use mmseg==1.2.0, `No such file mmseg/utils/bpe_simple_vocab_16e6.txt.gz` error happened.
From this [issue thread](https://github.com/open-mmlab/mmsegmentation/issues/3383), I found that the reason of this error is mmsegmentation itself.

## Change Details

Major Changes
- Change mmsegmentation version from 1.2.0 to 1.2.1.
- Add missing package installation (it raised another error in mmsegmentation)

Other Changes
- Change devcontainer setting to use black as a code formatter.
- Update `installation.md`

## How to use

See `installation.md`

## How you tested

<!--- Describe how the functionality was tested. Show how you ran unit tests on this functionality. --->

## Limitation (Optional)

<!--- Please describe any restrictions on this newly added feature --->

## Checklist

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.
